### PR TITLE
Install pym.js using bower

### DIFF
--- a/addon/components/file-renderer/component.js
+++ b/addon/components/file-renderer/component.js
@@ -20,10 +20,11 @@ import config from 'ember-get-config';
  * @class file-renderer
  */
 export default Ember.Component.extend({
-    didReceiveAttrs() {
+    didInsertElement() {
         this._super(...arguments);
         this.set('pymParent', new pym.Parent('mfrIframe', '', {}));
     },
+
     layout,
     download: null,
     width: '100%',

--- a/addon/components/file-renderer/template.hbs
+++ b/addon/components/file-renderer/template.hbs
@@ -3,7 +3,8 @@
     <button {{action 'hideHypothesis'}} type="button" class="btn btn-default btn-small">Hide Hypothesis Fancy</button>
 
     <p>MEOW MEOW MEOW MEOW</p>
-
-    <iframe id="mfrIframe" src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}}>
-    </iframe>
+    <div id='mfrIframe'>
+        <iframe src={{mfrUrl}} width={{width}} height={{height}} scrolling="yes" marginheight="0" frameborder="0" allowfullscreen={{allowfullscreen}}>
+        </iframe>
+    </div>
 {{/if}}

--- a/blueprints/ember-osf/index.js
+++ b/blueprints/ember-osf/index.js
@@ -25,5 +25,6 @@ module.exports = {
         } catch (e) {
             fs.renameSync(tmpConfigPath, configPath);
         }
+        return this.addBowerPackageToProject('pym');
     }
 };

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
     "jquery.tagsinput": "^1.3.6",
     "c3": "0.4.11",
     "d3": "3.5.17",
-    "bootstrap-daterangepicker": "^2.1.23"
+    "bootstrap-daterangepicker": "^2.1.23",
+    "pym.js": "^1.3.2"
   }, "devDependencies": {
     "bootstrap": "~3.3.5",
     "osf-style": "https://github.com/CenterforOpenScience/osf-style.git#1.3.0"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -46,7 +46,7 @@ module.exports = function(defaults) {
     app.import(path.join(app.bowerDirectory, 'osf-style/css/base.css'));
     app.import('vendor/assets/ember-osf.css');
 
-    app.import(path.join('node_modules','pym.js/dist/pym.v1.min.js'));
+    app.import(path.join(app.bowerDirectory,'pym.js/dist/pym.v1.js'));
 
     app.import({
         test: path.join(app.bowerDirectory, 'ember/ember-template-compiler.js')

--- a/index.js
+++ b/index.js
@@ -113,6 +113,8 @@ module.exports = {
             }
         }
 
+        this.import(path.join(app.bowerDirectory, 'pym.js/dist/pym.v1.js'));
+
         return app;
     },
     treeForAddon: function(tree) {


### PR DESCRIPTION
You'll also need to install pym.js via bower in `ember-osf-preprints`.

Got it working by following https://simplabs.com/blog/2017/02/13/npm-libs-in-ember-cli.html which explains the differences between apps and addons.

Related Interfaces ticket: https://openscience.atlassian.net/browse/IN-170
